### PR TITLE
Added "is_powered" predicate with addition "is_emitting option"

### DIFF
--- a/src/main/java/mod/omoflop/mbp/data/BlockModelPredicate.java
+++ b/src/main/java/mod/omoflop/mbp/data/BlockModelPredicate.java
@@ -33,6 +33,7 @@ public abstract class BlockModelPredicate implements WorldViewCondition {
         put("state", IsBlockState::parse);
         put("light_range", LightRange::parse);
         put("is_context", IsContext::parse);
+        put("is_powered", IsPowered::parse);
     }};
 
     public static ArrayList<BlockModelPredicate> parseFromJson(JsonElement element) {

--- a/src/main/java/mod/omoflop/mbp/data/conditions/IsPowered.java
+++ b/src/main/java/mod/omoflop/mbp/data/conditions/IsPowered.java
@@ -1,0 +1,44 @@
+package mod.omoflop.mbp.data.conditions;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import mod.omoflop.mbp.data.BlockModelPredicate;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.BlockView;
+
+public class IsPowered extends BlockModelPredicate {
+   private final boolean CHECK_IS_EMITTING;
+    public IsPowered(boolean emitting_arg) {
+	    CHECK_IS_EMITTING =emitting_arg;
+    }
+
+    @Override
+    public boolean meetsCondition(BlockView world, BlockPos pos, BlockState state, Identifier renderContext) {
+	    ClientWorld realWorld = MinecraftClient.getInstance().world;
+	    assert realWorld!= null;
+	    return	realWorld.isReceivingRedstonePower(pos) 			  &&
+	    (	    !CHECK_IS_EMITTING								  ||
+	    (		realWorld.isEmittingRedstonePower(pos, Direction.UP	) ||
+	    			realWorld.isEmittingRedstonePower(pos, Direction.DOWN	) ||
+	    			realWorld.isEmittingRedstonePower(pos, Direction.NORTH	) ||
+	    			realWorld.isEmittingRedstonePower(pos, Direction.SOUTH	) ||
+	    			realWorld.isEmittingRedstonePower(pos, Direction.EAST	) ||
+	    			realWorld.isEmittingRedstonePower(pos, Direction.WEST	)
+	    )
+	    );
+    }
+
+    public static IsPowered parse(JsonElement arg) {
+        JsonObject obj = arg.getAsJsonObject();
+	   
+	   boolean checkEmitting=false;
+	    if (obj.has("is_emitting")) checkEmitting = obj.get("is_emitting").getAsBoolean();
+	   
+	   return new IsPowered(checkEmitting);
+    }
+}


### PR DESCRIPTION
`"Is_powered":{}` checks if a block is receiving redstone power. true if yes, false if no.
`"Is_powered":{"is_emitting":true}"` additional checks if a block is emitting redstone power.

Futher steps for refining the predicate might include checking whether the block is capable of being powered / emmitting power, but it's my opinion that that's more the purview of resourcepack makers using the mod to correctly configure there packs than mod to police their configurations.
